### PR TITLE
add close tag to span element

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
             </section>
     
             <section id="footer">
-                <p>الصفحة الشخصية لاسم المسجل &copy; <span id="currentYear"></p>
+                <p>الصفحة الشخصية لاسم المسجل &copy; <span id="currentYear"></span></p>
             </section>
         </main>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>


### PR DESCRIPTION
This pull request fixes a syntax error in the HTML file. Previously, a closing tag for the <span> element was missing, causing rendering issues. The error has been fixed by adding the closing tag, and the HTML file now validates without any errors.

